### PR TITLE
Measure @Smell annotations that span lines

### DIFF
--- a/plugin/src/main/java/com/qualinsight/plugins/sonarqube/smell/plugin/extension/SmellMeasurer.java
+++ b/plugin/src/main/java/com/qualinsight/plugins/sonarqube/smell/plugin/extension/SmellMeasurer.java
@@ -27,14 +27,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import com.google.common.io.Files;		
-import org.apache.commons.io.Charsets;		
-import org.slf4j.Logger;		
-import org.slf4j.LoggerFactory;		
-import org.sonar.api.batch.SensorContext;		
+import com.google.common.io.Files;
+import org.apache.commons.io.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.measures.Measure;		
-import com.qualinsight.plugins.sonarqube.smell.api.annotation.Smell;		
+import org.sonar.api.measures.Measure;
+import com.qualinsight.plugins.sonarqube.smell.api.annotation.Smell;
 import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
 
 /**

--- a/plugin/src/main/java/com/qualinsight/plugins/sonarqube/smell/plugin/extension/SmellMeasurer.java
+++ b/plugin/src/main/java/com/qualinsight/plugins/sonarqube/smell/plugin/extension/SmellMeasurer.java
@@ -19,15 +19,6 @@
  */
 package com.qualinsight.plugins.sonarqube.smell.plugin.extension;
 
-import com.google.common.io.Files;
-import com.qualinsight.plugins.sonarqube.smell.api.annotation.Smell;
-import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
-import org.apache.commons.io.Charsets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sonar.api.batch.SensorContext;
-import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.measures.Measure;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -36,6 +27,15 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import com.google.common.io.Files;		
+import org.apache.commons.io.Charsets;		
+import org.slf4j.Logger;		
+import org.slf4j.LoggerFactory;		
+import org.sonar.api.batch.SensorContext;		
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.measures.Measure;		
+import com.qualinsight.plugins.sonarqube.smell.api.annotation.Smell;		
+import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
 
 /**
  * Helper class that scans {@link InputFile}s for the presence of {@link Smell} annotations and saves {@link Measure}s accordingly.

--- a/plugin/src/main/java/com/qualinsight/plugins/sonarqube/smell/plugin/extension/SmellMeasurer.java
+++ b/plugin/src/main/java/com/qualinsight/plugins/sonarqube/smell/plugin/extension/SmellMeasurer.java
@@ -48,9 +48,9 @@ public final class SmellMeasurer {
 
     private static final String EMPTY_FILE_CONTENT = "";
 
-    private static final String SMELL_ANNOTATION_TYPE_DETECTION_REGULAR_EXPRESSION = "@(com\\.qualinsight\\.plugins\\.sonarqube\\.smell\\.api\\.annotation\\.)?Smell\\(.*type\\s?=\\s?(SmellType\\.)?([A-Z_]+).*?\\)";
+    private static final String SMELL_ANNOTATION_TYPE_DETECTION_REGULAR_EXPRESSION = "@(com\\.qualinsight\\.plugins\\.sonarqube\\.smell\\.api\\.annotation\\.)?Smell\\((?s).*type\\s?=\\s?(SmellType\\.)?([A-Z_]+).*?\\)";
 
-    private static final String SMELL_ANNOTATION_DEBT_DETECTION_REGULAR_EXPRESSION = "@(com\\.qualinsight\\.plugins\\.sonarqube\\.smell\\.api\\.annotation\\.)?Smell\\(.*minutes\\s?=\\s?(\\d+).*?\\)";
+    private static final String SMELL_ANNOTATION_DEBT_DETECTION_REGULAR_EXPRESSION = "@(com\\.qualinsight\\.plugins\\.sonarqube\\.smell\\.api\\.annotation\\.)?Smell\\((?s).*minutes\\s?=\\s?(\\d+).*?\\)";
 
     private SensorContext context;
 

--- a/plugin/src/main/java/com/qualinsight/plugins/sonarqube/smell/plugin/extension/SmellMeasurer.java
+++ b/plugin/src/main/java/com/qualinsight/plugins/sonarqube/smell/plugin/extension/SmellMeasurer.java
@@ -19,6 +19,15 @@
  */
 package com.qualinsight.plugins.sonarqube.smell.plugin.extension;
 
+import com.google.common.io.Files;
+import com.qualinsight.plugins.sonarqube.smell.api.annotation.Smell;
+import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
+import org.apache.commons.io.Charsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.SensorContext;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.measures.Measure;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -27,15 +36,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import com.google.common.io.Files;
-import org.apache.commons.io.Charsets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.sonar.api.batch.SensorContext;
-import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.measures.Measure;
-import com.qualinsight.plugins.sonarqube.smell.api.annotation.Smell;
-import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
 
 /**
  * Helper class that scans {@link InputFile}s for the presence of {@link Smell} annotations and saves {@link Measure}s accordingly.
@@ -48,9 +48,9 @@ public final class SmellMeasurer {
 
     private static final String EMPTY_FILE_CONTENT = "";
 
-    private static final String SMELL_ANNOTATION_TYPE_DETECTION_REGULAR_EXPRESSION = "@(com\\.qualinsight\\.plugins\\.sonarqube\\.smell\\.api\\.annotation\\.)?Smell\\((?s).*type\\s?=\\s?(SmellType\\.)?([A-Z_]+).*?\\)";
+    private static final String SMELL_ANNOTATION_TYPE_DETECTION_REGULAR_EXPRESSION = "@(com\\.qualinsight\\.plugins\\.sonarqube\\.smell\\.api\\.annotation\\.)?Smell\\((?s).*?type\\s?=\\s?(SmellType\\.)?([A-Z_]+).*?\\)";
 
-    private static final String SMELL_ANNOTATION_DEBT_DETECTION_REGULAR_EXPRESSION = "@(com\\.qualinsight\\.plugins\\.sonarqube\\.smell\\.api\\.annotation\\.)?Smell\\((?s).*minutes\\s?=\\s?(\\d+).*?\\)";
+    private static final String SMELL_ANNOTATION_DEBT_DETECTION_REGULAR_EXPRESSION = "@(com\\.qualinsight\\.plugins\\.sonarqube\\.smell\\.api\\.annotation\\.)?Smell\\((?s).*?minutes\\s?=\\s?(\\d+).*?\\)";
 
     private SensorContext context;
 

--- a/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
+++ b/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
@@ -19,7 +19,8 @@
  */
 package com.qualinsight.plugins.sonarqube.smell.internal.extension;
 
-import java.io.File;
+import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
+import com.qualinsight.plugins.sonarqube.smell.plugin.extension.SmellMeasurer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
@@ -29,8 +30,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.measures.Metric;
-import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
-import com.qualinsight.plugins.sonarqube.smell.plugin.extension.SmellMeasurer;
+import java.io.File;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SmellMeasurerTest {
@@ -100,6 +100,21 @@ public class SmellMeasurerTest {
         // total debt should be saved once with sum of annotations minutes
         Mockito.verify(this.sensorContext, Mockito.times(1))
             .saveMeasure(Matchers.eq(this.inputFile), Matchers.any(Metric.class), Matchers.eq(80d));
+        Mockito.verifyNoMoreInteractions(this.sensorContext);
+    }
+
+    @Test
+    public void measure_with_annotatedFile_should_saveExpectedMeasuresThatHaveLineBreaksInAnnotations() {
+        Mockito.when(this.inputFile.file())
+                .thenReturn(new File("src/test/resources/SmellMeasurerTest_5.java"));
+        final SmellMeasurer sut = new SmellMeasurer(this.sensorContext);
+        sut.measure(this.inputFile);
+        // different metrics should be saved, one for each SmellType
+        Mockito.verify(this.sensorContext, Mockito.times(SmellType.values().length))
+                .saveMeasure(Matchers.eq(this.inputFile), Matchers.any(Metric.class), Matchers.eq(1d));
+        // total debt should be saved once with sum of annotations minutes
+        Mockito.verify(this.sensorContext, Mockito.times(1))
+                .saveMeasure(Matchers.eq(this.inputFile), Matchers.any(Metric.class), Matchers.eq(EXPECTED_SmellTYPE_DEBT));
         Mockito.verifyNoMoreInteractions(this.sensorContext);
     }
 

--- a/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
+++ b/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
@@ -19,7 +19,7 @@
  */
 package com.qualinsight.plugins.sonarqube.smell.internal.extension;
 
-import java.io.File
+import java.io.File;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;

--- a/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
+++ b/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
@@ -19,8 +19,8 @@
  */
 package com.qualinsight.plugins.sonarqube.smell.internal.extension;
 
-import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
-import com.qualinsight.plugins.sonarqube.smell.plugin.extension.SmellMeasurer;
+import java.io.file
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
@@ -30,7 +30,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.measures.Metric;
-import java.io.File;
+import com.qualinsight.plugins.sonarqube.smell.api.model.SmellType;
+import com.qualinsight.plugins.sonarqube.smell.plugin.extension.SmellMeasurer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SmellMeasurerTest {

--- a/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
+++ b/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
@@ -19,7 +19,7 @@
  */
 package com.qualinsight.plugins.sonarqube.smell.internal.extension;
 
-import java.io.file
+import java.io.File
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;

--- a/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
+++ b/plugin/src/test/java/com/qualinsight/plugins/sonarqube/smell/internal/extension/SmellMeasurerTest.java
@@ -20,7 +20,6 @@
 package com.qualinsight.plugins.sonarqube.smell.internal.extension;
 
 import java.io.file
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;

--- a/plugin/src/test/resources/SmellMeasurerTest_5.java
+++ b/plugin/src/test/resources/SmellMeasurerTest_5.java
@@ -1,0 +1,121 @@
+import com.qualinsight.plugins.sonarqube.Smell.api.annotation.Smell;
+import com.qualinsight.plugins.sonarqube.Smell.api.model.SmellType;
+
+public class SmellMeasurerTest_1 {
+    
+    @Smell(minutes=10,
+           type=SmellType.ABBREVIATIONS_USAGE,
+           reason="")
+    Object field1;
+    
+    @Smell(type=SmellType.ANTI_PATTERN,
+           minutes=10,
+           reason="")
+    Object field2;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.BAD_DESIGN)
+    Object field3;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.BAD_FRAMEWORK_USAGE)
+    Object field20;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.BAD_LOGGING)
+    Object field4;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.HOW_COMMENT)
+    Object field5;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.INDECENT_EXPOSURE)
+    Object field6;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.MEANINGLESS_COMMENT)
+    Object field7;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.MIDDLE_MAN)
+    Object field8;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.MISSING_IMPLEMENTATION)
+    Object field9;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.MULTIPLE_RESPONSIBILITIES)
+    Object field10;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.NON_EXCEPTION)
+    Object field11;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.ODDBALL_SOLUTION)
+    Object field12;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.OVERCOMPLICATED_ALGORITHM)
+    Object field13;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.PRIMITIVES_OBSESSION)
+    Object field14;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.REFUSED_BEQUEST)
+    Object field15;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.REINVENTED_WHEEL)
+    Object field16;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.SOLUTION_SPRAWL)
+    Object field17;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.SPECULATIVE_GENERALITY)
+    Object field18;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.UNCOMMUNICATIVE_NAME)
+    Object field19;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.USELESS_TEST)
+    Object field21;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.WRONG_LANGUAGE)
+    Object field22;
+    
+    @Smell(minutes=10,
+           reason="",
+           type=SmellType.WRONG_LOGIC)
+    Object field23;
+    
+}


### PR DESCRIPTION
We're running sonar 5.1.2 and noticed that our even though the smell rules were detecting the annotation, nothing was showing up as metrics.  We realized it's because our @Smell annotation is normally spread across 3 lines in order to not violate coding standards.  This change will measure @Smell annotations that span lines.